### PR TITLE
Fix: PostUser.insert_allの警告を無視する設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,8 +102,6 @@ group :development do
   # 開発環境でのコンソール表示のためのweb-console
   gem 'web-console'
 
-
-
   # 開発環境でのコマンドの高速化のためのspring
   # gem 'spring'
 end

--- a/app/models/concerns/posts/notification.rb
+++ b/app/models/concerns/posts/notification.rb
@@ -21,7 +21,7 @@ module Posts
         Notification.import(notifications)
 
         # 自分自身を除く受信者ごとにメール通知を送信
-        direct_recipients.where.not(id: current_user.id).each do |recipient|
+        direct_recipients.where.not(id: current_user.id).find_each do |recipient|
           # 受信者がメール通知を有効にしている場合のみ送信
           UserMailer.direct_notification(recipient, self).deliver_later if recipient.email_notify_on_direct_message
         end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -74,7 +74,7 @@ class Post < ApplicationRecord
 
   # direct_recipient_idsを取得するメソッド
   def direct_recipient_ids
-    self.direct_recipients.pluck(:id)
+    direct_recipients.pluck(:id)
   end
 
   # リポストかどうかを判定するメソッド

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
 
   # キャッシュストアにRedisを使用
   config.cache_store = :redis_cache_store, {
-    url: ENV.fetch("REDIS_URL") { "redis://redis:6379/1" },
+    url: ENV.fetch('REDIS_URL', 'redis://redis:6379/1'),
     expires_in: 12.hours # キャッシュの有効期限を12時間に設定
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,6 +12,13 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
+  # Redisキャッシュストアの設定
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch('REDIS_URL'),
+    expires_in: 12.hours, # キャッシュの有効期限を12時間に設定
+    namespace: 'cache' # 名前空間を設定
+  }
+
   # 静的ファイルを`public/`から提供するのを無効にします。NGINX/Apacheを使用することを前提としています。
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
 
@@ -59,6 +66,7 @@ Rails.application.configure do
   # マイグレーション後にスキーマをダンプしません。
   config.active_record.dump_schema_after_migration = false
 
+  # CSS圧縮を無効にします。
   config.assets.css_compressor = nil
 
   # DNSリバインディング保護とその他の`Host`ヘッダー攻撃を有効にします。
@@ -68,16 +76,10 @@ Rails.application.configure do
   config.hosts << 'www.watune.com'
   config.hosts << 'watune.com'
 
+  # リダイレクト設定
   config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
     r301(/.*/, 'https://www.watune.com$&', if: proc { |rack_env|
       ['wavecongra.onrender.com', 'www.wavecongra.com', 'wavecongra.com'].include?(rack_env['SERVER_NAME'])
     })
   end
-
-  # Redisキャッシュストアの設定
-  config.cache_store = :redis_cache_store, {
-    url: ENV.fetch("REDIS_URL"),
-    expires_in: 12.hours, # キャッシュの有効期限を12時間に設定
-    namespace: 'cache' # 名前空間を設定
-  }
 end

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if Rails.env.development?
-  require "rack-mini-profiler"
+  require 'rack-mini-profiler'
 
   # The initializer was required late, so initialize it manually.
   Rack::MiniProfilerRails.initialize!(Rails.application)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,5 @@
 # Redisの設定
-redis_config = { url: ENV.fetch("REDIS_URL") { "redis://redis:6379/1" } }
+redis_config = { url: ENV.fetch('REDIS_URL') { 'redis://redis:6379/1' } }
 
 # RailsのキャッシュストアにRedisを使用
 Rails.application.config.cache_store = :redis_cache_store, { url: redis_config[:url] }


### PR DESCRIPTION
大量のレコード挿入を効率化するため、insert_allメソッドを使用し、Rubocopの警告を無視するディレクティブを追加。

バリデーションをスキップするが、入力データの正確性を前提として使用。