### PR TITLE
Fix: サービスワーカーのキャッシュ管理を改善

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -6,13 +6,13 @@
     <div class="hidden md:block shrink-0">
       <%= link_to root_path do %>
         <%= image_tag ' logo-watune.png', alt: 'ロゴ', class: "h-[48px] lg:h-[64px] w-[200px] lg:w-[300px] w-auto rounded-full",
-            data: { turbo_frame: "advance" } %>
+            data: { turbo_frame: "_top" } %>
       <% end %>
     </div>
     <div class="md:hidden">
       <%= link_to root_path do %>
         <%= image_tag asset_path('logo-watune-en.png'), alt: 'ロゴ', class: "rounded-full h-[50px] w-[50px]",
-            data: { turbo_frame: "advance" } %>
+            data: { turbo_frame: "_top" } %>
       <% end %>
     </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,13 +5,13 @@
     <div class="hidden md-plus:block shrink-0 mx-5">
       <%= link_to posts_path do %>
         <%= image_tag ' logo-watune.png', alt: 'ロゴ', class: "h-[48px] lg:h-[64px] w-[200px] lg:w-[250px] rounded-full",
-            data: { turbo_frame: "advance" } %>
+            data: { turbo_frame: "_top" } %>
       <% end %>
     </div>
     <div class="md-plus:hidden mx-2">
       <%= link_to posts_path do %>
         <%= image_tag asset_path('logo-watune-en.png'), alt: 'ロゴ', class: "rounded-full h-[50px] w-[50px]",
-            data: { turbo_frame: "advance" } %>
+            data: { turbo_frame: "_top" } %>
       <% end %>
     </div>
 
@@ -23,11 +23,11 @@
       <% if current_user.guest %>
         <%= link_to 'いいねへ！', profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'),
             class: 'hidden sm-plus:flex btn btn-outline btn-secondary rounded-full sm-plus:btn-md sm-plus:text-lg',
-            data: { turbo_frame: "advance" } %>
+            data: { turbo_frame: "_top" } %>
       <% else %>
         <%= link_to 'いいねへ！', profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'),
             class: 'btn btn-outline btn-secondary btn-sm rounded-full text-sm sm-plus:btn-md sm-plus:text-lg',
-            data: { turbo_frame: "advance" } %>
+            data: { turbo_frame: "_top" } %>
       <% end %>
     </div>
 
@@ -49,17 +49,17 @@
       <!-- ユーザーメニュー -->
       <div class="z-40 dropdown dropdown-hover dropdown-end ml-2 shrink-0">
         <label tabindex="0" class="btn btn-ghost rounded-btn">
-          <%= image_tag (current_user.avatar.presence || asset_path('logo-watune-en.png')), class: "rounded-full h-10 w-10 min-w-[40px] md:h-12 md:w-12", data: { turbo_frame: "advance" } %>
+          <%= image_tag (current_user.avatar.presence || asset_path('logo-watune-en.png')), class: "rounded-full h-10 w-10 min-w-[40px] md:h-12 md:w-12", data: { turbo_frame: "_top" } %>
         </label>
         <ul tabindex="0" class="menu dropdown-content p-2 shadow bg-base-100 rounded-box" style="min-width: 300px; max-width: 600px;">
           <li class="py-2">
-            <%= link_to t('header.about'), root_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(root_path)}", data: { turbo_frame: "advance" } %>
+            <%= link_to t('header.about'), root_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(root_path)}", data: { turbo_frame: "_top" } %>
           </li>
           <li class="py-2">
-            <%= link_to t('header.post_index'), posts_path, class: "text-lg md:text-lg py-2 px-4 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(posts_path)}", data: { turbo_frame: "advance" } %>
+            <%= link_to t('header.post_index'), posts_path, class: "text-lg md:text-lg py-2 px-4 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(posts_path)}", data: { turbo_frame: "_top" } %>
           </li>
           <li class="block py-2">
-            <%= link_to profile_show_path(current_user.username_slug), class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(current_user.username_slug))}", data: { turbo_frame: "advance" } do %>
+            <%= link_to profile_show_path(current_user.username_slug), class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(current_user.username_slug))}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-user text-lg #{'text-blue-500' if current_page?(profile_show_path(current_user.username_slug))}"></i>
               <span>プロフィール</span>
             <% end %>
@@ -67,28 +67,28 @@
           <li class="block py-2 text-lg">
             <%= link_to profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'),
                 class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'))}",
-                data: { turbo_frame: "advance" } do %>
+                data: { turbo_frame: "_top" } do %>
               <i class="fas fa-heart text-lg #{'text-blue-500' if current_page?(profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'))}"></i>
               <span>いいねへ！<strong> <%= @likes_chance_count %>チャンス</strong></span>
             <% end %>
           </li>
           <li class="block py-2 text-lg">
-            <%= link_to users_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(users_path)}", data: { turbo_frame: "advance" } do %>
+            <%= link_to users_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(users_path)}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-users text-lg #{'text-blue-500' if current_page?(users_path)}"></i>
               <span>未フォロー<strong> <%= @unfollowed_users_count %>ユーザー</strong></span>
             <% end %>
           </li>
           <li class="block py-2">
-            <%= link_to edit_notification_settings_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(edit_notification_settings_path)}", data: { turbo_frame: "advance" } do %>
+            <%= link_to edit_notification_settings_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(edit_notification_settings_path)}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-cog text-lg #{'text-blue-500' if current_page?(edit_notification_settings_path)}"></i>
               <span>通知設定</span>
             <% end %>
           </li>
           <li class="py-2">
-            <%= link_to 'ログアウト', logout_path, method: :delete, data: { turbo_method: :delete, turbo_action: 'advance' }, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4", onclick: "unregisterServiceWorker()" %>
+            <%= link_to 'ログアウト', logout_path, method: :delete, data: { turbo_method: :delete, turbo_action: '_top' }, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4", onclick: "unregisterServiceWorker()" %>
           </li>
           <li class="py-2">
-            <%= link_to '退会する', user_path(current_user), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか（アカウント削除）？', turbo_action: 'advance' }, class: 'btn btn-danger' %>
+            <%= link_to '退会する', user_path(current_user), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか（アカウント削除）？', turbo_action: '_top' }, class: 'btn btn-danger' %>
           </li>
         </ul>
       </div>
@@ -123,34 +123,34 @@
             <%= link_to t('header.post_index'), posts_path, class: "block text-lg py-2 px-4 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(posts_path)}" %>
           </li>
           <li class="py-2">
-            <%= link_to profile_show_path(current_user.username_slug), class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(current_user.username_slug))}", data: { turbo_frame: "advance" } do %>
+            <%= link_to profile_show_path(current_user.username_slug), class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(current_user.username_slug))}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-user text-lg #{'text-blue-500' if current_page?(profile_show_path(current_user.username_slug))}"></i>
               <span>プロフィール</span>
             <% end %>
           </li>
           <li class="block py-2 text-lg">
-            <%= link_to profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'), class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'))}", data: { turbo_frame: "advance" } do %>
+            <%= link_to profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'), class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'))}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-heart text-lg #{'text-blue-500' if current_page?(profile_show_path(username_slug: current_user.username_slug, category: 'all_likes_chance'))}"></i>
               いいねへ！<strong> <%= @likes_chance_count %>チャンス</strong>
             <% end %>
           </li>
           <li class="block py-2 text-lg">
-            <%= link_to users_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(users_path)}", data: { turbo_frame: "advance" } do %>
+            <%= link_to users_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(users_path)}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-users text-lg #{'text-blue-500' if current_page?(users_path)}"></i>
               <span>未フォロー<strong> <%= @unfollowed_users_count %>ユーザー</strong>
             <% end %>
           </li>
           <li class="block py-2">
-            <%= link_to edit_notification_settings_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(edit_notification_settings_path)}", data: { turbo_frame: "advance" } do %>
+            <%= link_to edit_notification_settings_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(edit_notification_settings_path)}", data: { turbo_frame: "_top" } do %>
               <i class="fas fa-cog text-lg #{'text-blue-500' if current_page?(edit_notification_settings_path)}"></i>
               <span>通知設定</span>
             <% end %>
           </li>
           <li class="py-2">
-            <%= link_to 'ログアウト', logout_path, method: :delete, data: { turbo_method: :delete, turbo_action: 'advance' }, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4", onclick: "unregisterServiceWorker()" %>
+            <%= link_to 'ログアウト', logout_path, method: :delete, data: { turbo_method: :delete, turbo_action: '_top' }, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4", onclick: "unregisterServiceWorker()" %>
           </li>
           <li class="py-2">
-            <%= link_to '退会する', user_path(current_user), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか（アカウント削除）？', turbo_action: 'advance' }, class: 'btn btn-danger' %>
+            <%= link_to '退会する', user_path(current_user), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか（アカウント削除）？', turbo_action: '_top' }, class: 'btn btn-danger' %>
           </li>
         </ul>
       </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,27 +1,27 @@
 <aside id="after-sidebar" class="p-3 w-64 hidden md:block sticky top-[74px] h-[calc(100vh-74px)] overflow-y-auto">
   <div class="flex flex-col items-center mb-10 pt-2">
-    <%= link_to profile_show_path(current_user.username_slug), data: { turbo_frame: "advance" } do %>
+    <%= link_to profile_show_path(current_user.username_slug), data: { turbo_frame: "_top" } do %>
       <%= image_tag (current_user.avatar.presence || asset_path('logo-watune-en.png')), class: 'rounded-full h-32 w-32' %>
     <% end %>
   </div>
   <ul class="space-y-2">
     <!-- みんなのWave -->
     <li>
-      <%= link_to posts_path, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(posts_path)}", data: { turbo_frame: "advance" } do %>
+      <%= link_to posts_path, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(posts_path)}", data: { turbo_frame: "_top" } do %>
         <i class="fas fa-globe text-2xl #{'text-blue-500' if current_page?(posts_path)}"></i>
         <h2 class="text-lg font-bold flex-grow">みんなのウェーブ</h2>
       <% end %>
     </li>
     <!-- プロフィール -->
     <li>
-      <%= link_to profile_show_path(current_user.username_slug), class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(profile_show_path(current_user.username_slug))}", data: { turbo_frame: "advance" } do %>
+      <%= link_to profile_show_path(current_user.username_slug), class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(profile_show_path(current_user.username_slug))}", data: { turbo_frame: "_top" } do %>
         <i class="fas fa-user text-2xl #{'text-blue-500' if current_page?(profile_show_path(current_user.username_slug))}"></i>
         <h2 class="text-lg font-bold flex-grow">プロフィール</h2>
       <% end %>
     </li>
     <!-- 通知 -->
     <li>
-      <%= link_to notifications_path, method: :post, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(notifications_path)}", data: { turbo_frame: "advance" } do %>
+      <%= link_to notifications_path, method: :post, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(notifications_path)}", data: { turbo_frame: "_top" } do %>
         <div class="relative">
           <i class="fas fa-bell text-2xl #{'text-blue-500' if current_page?(notifications_path)}"></i>
           <% unread_notifications_count = current_user.received_notifications.unread.count %>
@@ -36,7 +36,7 @@
     </li>
     <!-- 通知設定 -->
     <li>
-      <%= link_to edit_notification_settings_path, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(edit_notification_settings_path)}", data: { turbo_frame: "advance" } do %>
+      <%= link_to edit_notification_settings_path, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(edit_notification_settings_path)}", data: { turbo_frame: "_top" } do %>
         <i class="fas fa-cog text-2xl #{'text-blue-500' if current_page?(edit_notification_settings_path)}"></i>
         <h2 class="text-lg font-bold flex-grow">通知設定</h2>
       <% end %>

--- a/app/views/shared/_widget.html.erb
+++ b/app/views/shared/_widget.html.erb
@@ -5,7 +5,7 @@
       <%= render partial: 'users/user', collection: users, as: :user %>
     </div>
     <div id="widget-load-more" class="mt-4 text-center">
-      <%= link_to 'さらに表示', users_path, data: { turbo_frame: "advance" }, class: "btn-load-more" %>
+      <%= link_to 'さらに表示', users_path, data: { turbo_frame: "_top" }, class: "btn-load-more" %>
     </div>
   </div>
 


### PR DESCRIPTION
キャッシュしないリソースがキャッシュされていた場合に、常に最新のリソースを取得し、古いキャッシュを削除するように修正しました。

初期読み込み時に必要な最低限のリソースとして/manifest.webmanifestのみをキャッシュし、その他のリソースはバックグラウンドでキャッシュするように変更しました。