### PR TITLE
Fix: rubocop警告(hange_column メソッドを使用したマイグレーションはリバーシブルでないため)

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,7 +21,7 @@ class PostsController < ApplicationController
                                       @post.privacy)
       end
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human, default: '投稿が作成されました。')
-      render json: { message: "Post created successfully", post: @post }, status: :created
+      render json: { message: 'Post created successfully', post: @post }, status: :created
     else
       flash.now[:danger] = t('defaults.flash_message.not_created', item: Post.model_name.human, default: '投稿の作成に失敗しました。')
       render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity

--- a/db/migrate/20240625211120_change_duration_to_decimal_in_posts.rb
+++ b/db/migrate/20240625211120_change_duration_to_decimal_in_posts.rb
@@ -1,5 +1,9 @@
 class ChangeDurationToDecimalInPosts < ActiveRecord::Migration[7.1]
-  def change
+  def up
     change_column :posts, :duration, :decimal, precision: 10, scale: 2
+  end
+
+  def down
+    change_column :posts, :duration, :integer
   end
 end


### PR DESCRIPTION
postsテーブルのdurationカラムをinteger型からdecimal型に変更するマイグレーションをリバーシブルに修正。upメソッドとdownメソッドを使用して、ロールバック時に元のinteger型に戻せるようにした。

rails db:rollback後にマイグレーションファイルを修正し、再度マイグレーションを実行。