### PR TITLE
Change: メインの画面サイズを670pxへ サイドバーのみんなのウェーブをホームへ

### DIFF
--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center min-h-screen">
-  <div class="max-w-[600px] w-full bg-white border border-gray-200">
+  <div class="max-w-[670px] w-full bg-white border border-gray-200">
     <h1 class="text-center font-bold text-xl mt-2"><%= @user.display_name %></h1>
     <p class="text-center text-sm">@<%= @user.username_slug %></p>
     <div class="c-tabs flex mb-2">

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center min-h-screen">
-  <div class="max-w-[600px] w-full bg-white border border-gray-200">
+  <div class="max-w-[670px] w-full bg-white border border-gray-200">
     <h1 class="text-xl font-bold mt-4 text-center">メール通知設定</h1>
 
     <%= form_with model: @user, url: notification_settings_path, local: true, class: "m-5" do |form| %>

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag 'profile_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 <div class="flex justify-center min-h-screen">
-  <div class="max-w-[600px] w-full bg-white border-x">
+  <div class="max-w-[670px] w-full bg-white border-x">
     <h1 class="text-center font-bold text-xl mt-2">通知</h1>
     <div class="c-tabs flex mb-2">
       <%= link_to notifications_path(category: 'all'), data: { turbo_frame: "_top" }, class: "c-tab #{active_tab_class('all', initial_category: 'all')} hover:bg-sky-100 text-center py-2" do %>

--- a/app/views/posts/_index.html.erb
+++ b/app/views/posts/_index.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag 'profile_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 <div class="flex justify-center min-h-screen">
-  <div class="max-w-[600px] w-full bg-white border-x">
+  <div class="max-w-[670px] w-full bg-white border-x">
     <% unless logged_in? %>
       <div class="flex justify-center my-4">
         <%= link_to 'このアプリについて', "#{root_path}#about", data: { turbo_frame: "_top" }, class: 'btn btn-outline btn-info btn-base sm:btn-lg rounded-full transition-colors duration-300' %>

--- a/app/views/posts/_posts_list.html.erb
+++ b/app/views/posts/_posts_list.html.erb
@@ -1,5 +1,5 @@
 <!-- 投稿一覧 -->
-<div class="mx-auto max-w-[600px] w-full">
+<div class="mx-auto max-w-[670px] w-full">
   <div id="post-list" class="grid grid-cols-1">
       <% if posts.present? %>
         <%= turbo_frame_tag "next-page" do %>

--- a/app/views/posts/_show.html.erb
+++ b/app/views/posts/_show.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag 'post_edit_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 <%= turbo_frame_tag "post_show" do %>
-  <div class="container min-h-screen max-w-[600px] mx-auto border-x">
+  <div class="container min-h-screen max-w-[670px] mx-auto border-x">
     <!-- 戻るボタン -->
     <div class="flex flex mx-auto justify-between bg-white px-[16px] h-[53px]">
       <div class="flex items-center w-[56px] h-[53px]">

--- a/app/views/posts/_test_posts_list.html.erb
+++ b/app/views/posts/_test_posts_list.html.erb
@@ -1,5 +1,5 @@
 <!-- 投稿一覧 -->
-<div class="mx-auto max-w-[600px] w-full border border-gray-200">
+<div class="mx-auto max-w-[670px] w-full border border-gray-200">
   <div id="post-list" class="grid grid-cols-1">
       <% if posts.present? %>
         <%= turbo_frame_tag "next-page" do %>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag 'reply_modal' %>
 <% content_for(:title, t('.title')) %>
 <div class="flex justify-center min-h-screen">
-  <div class="max-w-[600px] w-full bg-white border-x">
+  <div class="max-w-[670px] w-full bg-white border-x">
     <div class="pt-8">
       <%= render 'profiles/profile_info', user: @user %>
       <%= turbo_frame_tag "profile-posts" do %>

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -2,7 +2,7 @@
   <ul class="py-1 flex justify-around">
     <li class="flex-1 text-center">
       <%= link_to posts_path, class: "block py-2 #{'text-blue-500' if current_page?(posts_path)}" do %>
-        <i class="fas fa-globe text-2xl"></i>
+        <i class="fa-solid fa-house text-2xl"></i>
       <% end %>
     </li>
     <li class="flex-1 text-center">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -51,7 +51,7 @@
         <label tabindex="0" class="btn btn-ghost rounded-btn">
           <%= image_tag (current_user.avatar.presence || asset_path('logo-watune-en.png')), class: "rounded-full h-10 w-10 min-w-[40px] md:h-12 md:w-12", data: { turbo_frame: "_top" } %>
         </label>
-        <ul tabindex="0" class="menu dropdown-content p-2 shadow bg-base-100 rounded-box" style="min-width: 300px; max-width: 600px;">
+        <ul tabindex="0" class="menu dropdown-content p-2 shadow bg-base-100 rounded-box" style="min-width: 300px; max-width: 670px;">
           <li class="py-2">
             <%= link_to t('header.about'), about_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(about_path)}", data: { turbo_frame: "_top" } %>
           </li>
@@ -115,7 +115,7 @@
         <label tabindex="0" class="btn btn-ghost rounded-btn px-2">
           <%= image_tag (current_user.avatar.presence || asset_path('logo-watune-en.png')), class: "rounded-full h-10 w-10 min-w-[35px]" %>
         </label>
-        <ul tabindex="0" class="menu dropdown-content p-2 shadow bg-base-100 rounded-box" style="min-width: 300px; max-width: 600px;">
+        <ul tabindex="0" class="menu dropdown-content p-2 shadow bg-base-100 rounded-box" style="min-width: 300px; max-width: 670px;">
           <li class="py-2">
             <%= link_to t('header.about'), about_path, class: "text-lg hover:bg-sky-100 rounded-full transition-colors duration-300 px-4 #{active_if(about_path)}" %>
           </li>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<aside id="after-sidebar" class="p-5 w-[295px] hidden md:block sticky top-[74px] h-[calc(100vh-74px)] overflow-y-auto">
+<aside id="after-sidebar" class="p-5 w-[260px] hidden md:block sticky top-[74px] h-[calc(100vh-74px)] overflow-y-auto">
   <div class="flex flex-col items-center mb-10 pt-2">
     <%= link_to profile_show_path(current_user.username_slug), data: { turbo_frame: "_top" } do %>
       <%= image_tag (current_user.avatar.presence || asset_path('logo-watune-en.png')), class: 'rounded-full h-32 w-32' %>
@@ -8,8 +8,8 @@
     <!-- みんなのWave -->
     <li>
       <%= link_to posts_path, class: "flex items-center space-x-4 p-3 hover:bg-sky-100 rounded-full transition-colors duration-300 #{active_if(posts_path)}", data: { turbo_frame: "_top" } do %>
-        <i class="fas fa-globe text-2xl #{'text-blue-500' if current_page?(posts_path)}"></i>
-        <h2 class="text-xl font-bold flex-grow">みんなのウェーブ</h2>
+        <i class="fa-solid fa-house text-2xl #{'text-blue-500' if current_page?(posts_path)}"></i>
+        <h2 class="text-xl font-bold flex-grow">ホーム</h2>
       <% end %>
     </li>
     <!-- プロフィール -->

--- a/app/views/shared/_widget.html.erb
+++ b/app/views/shared/_widget.html.erb
@@ -1,4 +1,4 @@
-<div class="px-[20px] w-[385px] hidden lg:block overflow-y-auto">
+<div class="px-[20px] w-[350px] hidden lg:block overflow-y-auto">
   <div id="new-user-widget" class="<%= hide_widget_on_users_index %> border rounded-2xl my-4">
     <h2 class="text-xl text-center font-bold px-[16px] py-[12px]">未フォローのユーザー</h2>
     <div id="widget-users-list">

--- a/app/views/static_pages/_about.html.erb
+++ b/app/views/static_pages/_about.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-custom-screen relative" style="background-image: url('/images/sakura.JPG');">
   <div class="hero-overlay bg-opacity-60"></div>
   <div class="hero-content text-center relative text-neutral-content">
-    <div class="flex flex-col justify-center max-w-[600px] mx-auto">
+    <div class="flex flex-col justify-center max-w-[670px] mx-auto">
       <%= link_to guest_login_path, class: "invisible trial-btn text-xl sm:text-2xl mb-6" do %>
         お試しでいますぐ始める！<br>ログイン中で<br class="sm:hidden">データの引き継ぎ可能！
       <% end %>
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<div id="about" class="flex flex-col max-w-[600px] justify-center text-gray-900 container mx-auto py-12" style="background-image: url('#'); background-size: cover; background-position: center;">
+<div id="about" class="flex flex-col max-w-[670px] justify-center text-gray-900 container mx-auto py-12" style="background-image: url('#'); background-size: cover; background-position: center;">
   <section class="mb-12 text-center">
     <div class="rounded-full bg-sky-400-accent bg-opacity-50 px-3 py-8 sm:p-8 mx-auto max-w-2xl">
       <h2 class="text-3xl font-bold mb-4">サービス概要</h2>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex justify-center min-h-screen p-5">
-  <div class="max-w-[600px] w-full py-5 bg-white rounded-lg shadow-lg">
+  <div class="max-w-[670px] w-full py-5 bg-white rounded-lg shadow-lg">
     <h1 class="text-4xl font-bold mb-8 text-center">ログイン</h1>
     <%= form_with url: login_path do |f| %>
       <!-- Googleでログインのボタン -->

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center min-h-screen">
-  <div class="max-w-[600px] w-full bg-white border border-gray-200">
+  <div class="max-w-[670px] w-full bg-white border border-gray-200">
     <h2 class="text-xl text-center font-bold pt-2 mb-4">未フォローのユーザー</h2>
     <% if @recent_users.present? %>
       <%= turbo_frame_tag "next-page" do %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex justify-center min-h-screen p-5">
-  <div class="max-w-[600px] w-full bg-white rounded-lg shadow-lg">
+  <div class="max-w-[670px] w-full bg-white rounded-lg shadow-lg">
     <h1 class="text-4xl font-bold mt-5 mb-8 text-center">新規登録</h1>
     <%= form_with model: @user do |f| %>
       <div class="flex items-center justify-center mb-8">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased container width from `600px` to `670px` on multiple pages for improved layout and content accommodation.
  - Updated sidebar width from `295px` to `260px` for a streamlined appearance.
  - Changed icon class in bottom navigation from `fas fa-globe` to `fa-solid fa-house`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->