### PR TITLE
Refactor: PostsControllerの行数を減らし、TestPostsControllerを作成

### DIFF
--- a/app/controllers/test_posts_controller.rb
+++ b/app/controllers/test_posts_controller.rb
@@ -1,0 +1,35 @@
+class TestPostsController < ApplicationController
+  include PostsHelper
+  include ActionView::RecordIdentifier
+
+  before_action :set_followings_by_post_count, only: %i[new create]
+
+  def index
+    @show_reply_line = false
+    @pagy, @posts = pagy_countless(Post.order(created_at: :desc), items: 20)
+  end
+
+  # テスト用の音声投稿フォームを表示するアクション
+  def new
+    @post = Post.new
+    params[:privacy] ||= @post.privacy
+  end
+
+  def create
+    @post = current_user.posts.build(post_params.except(:recipient_ids))
+
+    if @post.save
+      cache_headers(@post.audio.blob) if @post.audio.attached?
+
+      respond_to do |format|
+        format.html { redirect_to user_post_path(current_user.username_slug, @post), notice: '投稿が作成されました。' }
+        format.json { render json: @post, status: :created }
+      end
+    else
+      respond_to do |format|
+        format.html { render :new, alert: '投稿の作成に失敗しました。' }
+        format.json { render json: @post.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+end

--- a/app/views/posts/index/_category_tabs.html.erb
+++ b/app/views/posts/index/_category_tabs.html.erb
@@ -10,6 +10,9 @@
       <%= link_to posts_path(category: 'app_review'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'app_review'))} hover:bg-sky-100 text-center py-2" do %>
         <i class="fa fa-star-half-alt text-green-500 mr-1 sm:mr-2"></i><span>アプリレビュー</span>
       <% end %>
+      <%= link_to posts_path(category: 'tech'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'tech'))} hover:bg-sky-100 text-center py-2" do %>
+        <i class="fa fa-child text-pink-500 mr-1 sm:mr-2"></i><span>技術</span>
+      <% end %>
       <%= link_to posts_path(category: 'child'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'child'))} hover:bg-sky-100 text-center py-2" do %>
         <i class="fa fa-child text-pink-500 mr-1 sm:mr-2"></i><span>子供の声</span>
       <% end %>

--- a/app/views/posts/index/_category_tabs.html.erb
+++ b/app/views/posts/index/_category_tabs.html.erb
@@ -2,7 +2,7 @@
   <div id="post-category-tabs" class="z-10">
     <div class="c-tabs flex overflow-x-auto whitespace-nowrap pb-2" id="post-category-tabs-container">
       <%= link_to posts_path(category: 'recommended'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{('active' if params[:category].nil?) || active_if(posts_path(category: 'recommended'))} hover:bg-sky-100 text-center py-2" do %>
-        <i class="fa fa-star text-yellow-500 mr-1 sm:mr-2"></i><span>おすすめ</span>
+        <i class="fa fa-star text-yellow-700-accent mr-1 sm:mr-2"></i><span>おすすめ</span>
       <% end %>
       <%= link_to posts_path(category: 'music'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'music'))} hover:bg-sky-100 text-center py-2" do %>
         <i class="fa fa-music text-blue-500 mr-1 sm:mr-2"></i><span>音楽</span>
@@ -11,22 +11,22 @@
         <i class="fa fa-star-half-alt text-green-500 mr-1 sm:mr-2"></i><span>アプリレビュー</span>
       <% end %>
       <%= link_to posts_path(category: 'tech'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'tech'))} hover:bg-sky-100 text-center py-2" do %>
-        <i class="fa fa-child text-pink-500 mr-1 sm:mr-2"></i><span>技術</span>
+        <i class="fa-solid fa-lightbulb text-yellow-700-accent mr-1 sm:mr-2"></i><span>技術</span>
       <% end %>
       <%= link_to posts_path(category: 'child'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'child'))} hover:bg-sky-100 text-center py-2" do %>
-        <i class="fa fa-child text-pink-500 mr-1 sm:mr-2"></i><span>子供の声</span>
+        <i class="fa fa-smile-o text-pink-400 mr-1 sm:mr-2"></i><span>子供の声</span>
       <% end %>
       <%= link_to posts_path(category: 'favorite'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'favorite'))} hover:bg-sky-100 text-center py-2" do %>
         <i class="fa fa-heart text-red-500 mr-1 sm:mr-2"></i><span>好きなこと</span>
       <% end %>
-      <%= link_to posts_path(category: 'other'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'other'))} hover:bg-sky-100 text-center py-2" do %>
-        <i class="fa fa-ellipsis-h text-gray-500 mr-1 sm:mr-2"></i><span>その他</span>
-      <% end %>
       <%= link_to posts_path(category: 'grateful'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'grateful'))} hover:bg-sky-100 text-center py-2" do %>
-        <i class="fa-solid fa-hands-praying text-purple-500 mr-1 sm:mr-2"></i><span>感謝</span>
+        <i class="fa-solid fa-hands-praying text-purple-400 mr-1 sm:mr-2"></i><span>感謝</span>
       <% end %>
       <%= link_to posts_path(category: 'blessing'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'blessing'))} hover:bg-sky-100 text-center py-2" do %>
-        <i class="fa fa-hand-sparkles text-yellow-500 mr-1 sm:mr-2"></i><span>祝福</span>
+        <i class="fa fa-hand-sparkles text-yellow-700-accent mr-1 sm:mr-2"></i><span>祝福</span>
+      <% end %>
+      <%= link_to posts_path(category: 'other'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'other'))} hover:bg-sky-100 text-center py-2" do %>
+        <i class="fa fa-ellipsis-h text-gray-500 mr-1 sm:mr-2"></i><span>その他</span>
       <% end %>
       <%= link_to posts_path(category: 'monologue'), data: { turbo_frame: "open-posts" }, class: "c-post-tab #{active_if(posts_path(category: 'monologue'))} hover:bg-sky-100 text-center py-2" do %>
         <i class="fa fa-comment-dots text-teal-500 mr-1 sm:mr-2"></i><span>ひとりごと</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,13 +60,12 @@ Rails.application.routes.draw do
   get '/:username_slug/status/:id/reply_modal', to: 'replies#new_modal', as: 'new_reply_modal'
   post '/:username_slug/status/:id/reply_modal', to: 'replies#create_modal', as: 'create_reply_modal'
 
-  # テスト用の音声投稿ページのルートを追加
-  get 'posts/new_test', to: 'posts#new_test', as: 'new_test_post'
-
-  # テスト用の新しい投稿作成ルート
-  post 'posts/create_test', to: 'posts#create_test', as: 'create_test_post'
-
-  get '/posts/index_test', to: 'posts#index_test', as: :index_test_post
+  # TestPostsController用のルートを追加
+  namespace :test_posts do
+    get 'new', to: 'test_posts#new', as: 'new'
+    post 'create', to: 'test_posts#create', as: 'create'
+    get 'index', to: 'test_posts#index', as: 'index'
+  end
 
   # PostUserのルーティング（投稿受信者管理）
   resources :post_users, only: %i[show create destroy]

--- a/db/migrate/20240705090235_add_unique_index_to_categories.rb
+++ b/db/migrate/20240705090235_add_unique_index_to_categories.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToCategories < ActiveRecord::Migration[7.1]
+  def change
+    # 既存のインデックスを削除
+    remove_index :categories, :add_category_name if index_exists?(:categories, :add_category_name)
+
+    # ユニークインデックスを追加
+    add_index :categories, :add_category_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_05_044958) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_05_090235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,7 +67,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_044958) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "add_category_name"
-    t.index ["add_category_name"], name: "index_categories_on_add_category_name"
+    t.index ["add_category_name"], name: "index_categories_on_add_category_name", unique: true
     t.index ["category_name"], name: "index_categories_on_category_name", unique: true
   end
 


### PR DESCRIPTION
既存のadd_category_nameインデックスを削除し、ユニークインデックスを追加するマイグレーションを作成。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new tab for the 'tech' category with corresponding icon and styling.

- **Refactor**
  - Improved category-based post retrieval in the `PostsController` for more efficient processing.

- **Bug Fixes**
  - Updated routes for `TestPostsController` to reflect new naming conventions.

- **Database**
  - Added a unique index to the `categories` table to ensure category names are unique.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->