### PR TITLE
Change: 名前クリックはモーダルでなくプロフィール遷移へ

### DIFF
--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -1,7 +1,6 @@
 <turbo-frame id="main-content">
 <%= turbo_frame_tag 'post_edit_modal' %>
 <%= turbo_frame_tag "profile_edit_modal" %>
-<%= turbo_frame_tag 'profile_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 <div class="flex justify-center min-h-screen">
   <div class="max-w-[670px] w-full bg-white border-x">

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -5,7 +5,7 @@
       <%= link_to profile_show_path(username_slug: notification.sender.username_slug), data: { turbo_frame: "main-content", turbo_action: :advance } do %>
         <%= image_tag(notification.sender.avatar.presence || asset_path('logo-watune-en.png'), alt: "プロフィール画像", class: "mx-2 rounded-full min-w-[32px] min-h-[32px] max-w-[32px] max-h-[32px]") %>
       <% end %>
-      <%= link_to profile_modal_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "profile_modal" } do %>
+      <%= link_to profile_show_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "_top" } do %>
         <%= notification.sender.display_name %>
       <% end %>
       <span class="text-[15px]">さんがあなたの投稿にいいねしました。</span>
@@ -17,7 +17,7 @@
       <%= link_to profile_show_path(username_slug: notification.sender.username_slug), data: { turbo_frame: "main-content", turbo_action: :advance } do %>
         <%= image_tag(notification.sender.avatar.presence || asset_path('logo-watune-en.png'), alt: "プロフィール画像", class: "mx-2 rounded-full min-w-[32px] min-h-[32px] max-w-[32px] max-h-[32px]") %>
       <% end %>
-      <%= link_to profile_modal_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "profile_modal" } do %>
+      <%= link_to profile_show_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "_top" } do %>
         <%= notification.sender.display_name %>
       <% end %>
       <span class="text-[15px]">さんがあなたへ返信しました。</span>
@@ -29,7 +29,7 @@
       <%= link_to profile_show_path(username_slug: notification.sender.username_slug), data: { turbo_frame: "main-content", turbo_action: :advance } do %>
         <%= image_tag(notification.sender.avatar.presence || asset_path('logo-watune-en.png'), alt: "プロフィール画像", class: "mx-2 rounded-full min-w-[32px] min-h-[32px] max-w-[32px] max-h-[32px]") %>
       <% end %>
-      <%= link_to profile_modal_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "profile_modal" } do %>
+      <%= link_to profile_show_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "_top" } do %>
         <%= notification.sender.display_name %>
       <% end %>
       <span class="text-[15px]">さんがあなたの投稿をリウェーブしました。</span>
@@ -41,7 +41,7 @@
       <%= link_to profile_show_path(username_slug: notification.sender.username_slug), data: { turbo_frame: "_top, turbo_action: :advance" } do %>
         <%= image_tag(notification.sender.avatar.presence || asset_path('logo-watune-en.png'), alt: "プロフィール画像", class: "mx-2 rounded-full min-w-[32px] min-h-[32px] max-w-[32px] max-h-[32px]") %>
       <% end %>
-      <%= link_to profile_modal_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "profile_modal" } do %>
+      <%= link_to profile_show_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "_top" } do %>
         <%= notification.sender.display_name %>
       <% end %>
       <span class="text-[15px]">さんがあなたをフォローしました。</span>
@@ -52,7 +52,7 @@
       <%= link_to profile_show_path(username_slug: notification.sender.username_slug), data: { turbo_frame: "main-content", turbo_action: :advance } do %>
         <%= image_tag(notification.sender.avatar.presence || asset_path('logo-watune-en.png'), alt: "プロフィール画像", class: "mx-2 rounded-full min-w-[32px] min-h-[32px] max-w-[32px] max-h-[32px]") %>
       <% end %>
-      <%= link_to profile_modal_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "profile_modal" } do %>
+      <%= link_to profile_show_path(username_slug: notification.sender.username_slug), class: "text-[15px] font-semibold", data: { turbo_frame: "_top" } do %>
         <%= notification.sender.display_name %>
       <% end %>
       <span class="text-[15px]">さんがあなたへ投稿しました。</span>

--- a/app/views/posts/_index.html.erb
+++ b/app/views/posts/_index.html.erb
@@ -1,7 +1,6 @@
 <turbo-frame id="main-content" data-controller="post-index">
   <%= turbo_frame_tag 'post_edit_modal' %>
   <%= turbo_frame_tag "profile_edit_modal" %>
-  <%= turbo_frame_tag 'profile_modal' %>
   <%= turbo_frame_tag 'reply_modal' %>
 
   <div class="flex justify-center min-h-screen">

--- a/app/views/posts/_index_test.html.erb
+++ b/app/views/posts/_index_test.html.erb
@@ -1,6 +1,5 @@
 <%= turbo_frame_tag 'post_edit_modal' %>
 <%= turbo_frame_tag "profile_edit_modal" %>
-<%= turbo_frame_tag 'profile_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 <% content_for(:title, t('.title')) %>
 <div class="container">

--- a/app/views/posts/_repost.html.erb
+++ b/app/views/posts/_repost.html.erb
@@ -6,7 +6,7 @@
     <div class="flex items-center space-x-2 overflow-x-auto whitespace-nowrap pb-2 pl-[8px]">
       <i class="fa-solid fa-retweet text-base text-green-500"></i>
       <% post.reposts.order(created_at: :desc).each_with_index do |repost, index| %>
-        <%= link_to profile_modal_path(username_slug: repost.user.username_slug), class: "text-[13px] font-semibold text-green-500 hover:underline ml-[2px]", data: { turbo_frame: "profile_modal" } do %>
+        <%= link_to profile_show_path(username_slug: repost.user.username_slug), class: "text-[13px] font-semibold text-green-500 hover:underline ml-[2px]", data: { turbo_frame: "_top" } do %>
           <% repost_user_is_current_user = repost.user == current_user %>
           <%= repost_user_is_current_user ? "あなた" : "#{repost.user.display_name}さん" %>
         <% end %>

--- a/app/views/posts/_show.html.erb
+++ b/app/views/posts/_show.html.erb
@@ -1,6 +1,5 @@
 <turbo-frame id="main-content">
 <%= turbo_frame_tag "profile_edit_modal" %>
-<%= turbo_frame_tag 'profile_modal' %>
 <%= turbo_frame_tag 'post_edit_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 

--- a/app/views/posts/shared/_user_info.html.erb
+++ b/app/views/posts/shared/_user_info.html.erb
@@ -1,6 +1,8 @@
 <div class="max-w-[293px] sm:max-w-[592px] flex justify-between items-center mb-2">
   <div class="overflow-x-auto whitespace-nowrap pb-2 max-w-[80%]">
-    <%= link_to profile_modal_path(username_slug: post.user.username_slug), class: "flex items-center text-[15px] font-semibold text-black hover:underline", data: { turbo_frame: "profile_modal" } do %>
+    <%= link_to profile_show_path(username_slug: post.user.username_slug),
+                data: { turbo_frame: "_top", turbo_action: :advance },
+                class: "flex items-center text-lg font-semibold text-black hover:underline" do %>
       <%= post.user.display_name %>
     <% end %>
     <span class="text-[15px] text-gray-500">@<%= post.user.username_slug %></span>
@@ -9,9 +11,9 @@
       <div class="text-[15px] text-gray-500">
         <span>宛先:</span>
         <% post.direct_recipients.each do |recipient| %>
-          <%= link_to profile_modal_path(username_slug: recipient.username_slug),
-                      class: "text-blue-500 font-semibold hover:underline",
-                      data: { turbo_frame: "profile_modal" } do %>
+          <%= link_to profile_show_path(username_slug: recipient.username_slug),
+                      data: { turbo_frame: "_top", turbo_action: :advance },
+                      class: "text-blue-500 font-semibold hover:underline" do %>
             <%= recipient.display_name %><span class="font-normal">さん</span>
           <% end %>
         <% end %>
@@ -37,9 +39,9 @@
     返信先: 
     <% post.ancestors.map(&:user).uniq.each do |user| %>
       <% unless post.user.id == user.id %>
-        <%= link_to profile_modal_path(username_slug: user.username_slug),
+        <%= link_to profile_show_path(username_slug: user.username_slug),
                     class: "text-blue-500 font-semibold hover:underline",
-                    data: { turbo_frame: "profile_modal" } do %>
+                    data: { turbo_frame: "_top", turbo_action: :advance  } do %>
           <%= user.display_name %><span class="font-normal">さん</span>
         <% end %>
       <% end %>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -1,6 +1,5 @@
 <turbo-frame id="main-content">
 <%= turbo_frame_tag 'post_edit_modal' %>
-<%= turbo_frame_tag 'profile_modal' %>
 <%= turbo_frame_tag 'reply_modal' %>
 <% content_for(:title, t('.title')) %>
 <div class="flex justify-center min-h-screen">

--- a/app/views/replies/_form_fields.html.erb
+++ b/app/views/replies/_form_fields.html.erb
@@ -21,19 +21,19 @@
         <div class="text-lg text-gray-500 mb-2">
           <% if post.user.present? %>
             <!-- 返信先の投稿が存在する場合 -->
-            <!-- 投稿のユーザー名にリンクを設定し、モーダルでプロフィールを表示 -->
-            <%= link_to profile_modal_path(username_slug: post.user.username_slug),
+            <!-- 投稿のユーザー名にリンクを設定し、プロフィールリンクを表示 -->
+            <%= link_to profile_show_path(username_slug: post.user.username_slug),
                         class: "text-xl font-semibold text-blue-500 hover:underline",
-                        data: { turbo_frame: "profile_modal" } do %>
+                        data: { turbo_frame: "_top", turbo_action: :advance } do %>
               <%= post.user.display_name %><span class="font-normal">さん</span>
             <% end %><br>
 
             <!-- 投稿の祖先（リプライ元）ユーザーを一意に取得し、リンクを設定 -->
             <% post.ancestors.map(&:user).uniq.each do |user| %>
               <% unless user == current_user %>
-                <%= link_to profile_modal_path(username_slug: user.username_slug),
+                <%= link_to profile_show_path(username_slug: user.username_slug),
                             class: "text-blue-500 hover:underline",
-                            data: { turbo_frame: "profile_modal" } do %>
+                            data: { turbo_frame: "_top", turbo_action: :advance } do %>
                   <%= user.display_name %><span class="font-normal">さん</span>
                 <% end %>
                 <% unless user == post.ancestors.map(&:user).uniq.last %>、<% end %>

--- a/app/views/replies/_user_info_modal.html.erb
+++ b/app/views/replies/_user_info_modal.html.erb
@@ -1,6 +1,8 @@
 <div class="max-w-[263.75px] sm:max-w-[432px] flex justify-between items-center mb-2">
   <div class="overflow-x-auto whitespace-nowrap pb-2 max-w-[80%]">
-    <%= link_to profile_modal_path(username_slug: post.user.username_slug), class: "flex items-center text-lg font-semibold text-black hover:underline", data: { turbo_frame: "profile_modal" } do %>
+    <%= link_to profile_show_path(username_slug: post.user.username_slug),
+        data: { turbo_frame: "main-content", turbo_action: :advance },
+        class: "flex items-center text-lg font-semibold text-black hover:underline" do %>
       <%= post.user.display_name %>
     <% end %>
     <span class="text-base text-gray-500">@<%= post.user.username_slug %></span>
@@ -9,9 +11,9 @@
       <div class="text-base text-gray-500">
         <span>宛先:</span>
         <% post.direct_recipients.each do |recipient| %>
-          <%= link_to profile_modal_path(username_slug: recipient.username_slug),
+          <%= link_to profile_show_path(username_slug: recipient.username_slug),
                       class: "text-blue-500 font-semibold hover:underline",
-                      data: { turbo_frame: "profile_modal" } do %>
+                      data: { turbo_frame: "_top", turbo_action: :advance } do %>
             <%= recipient.display_name %><span class="font-normal">さん</span>
           <% end %>
         <% end %>
@@ -37,9 +39,9 @@
     返信先: 
     <% post.ancestors.map(&:user).uniq.each do |user| %>
       <% unless post.user.id == user.id %>
-        <%= link_to profile_modal_path(username_slug: user.username_slug),
+        <%= link_to profile_show_path(username_slug: user.username_slug),
                     class: "text-blue-500 font-semibold hover:underline",
-                    data: { turbo_frame: "profile_modal" } do %>
+                    data: { turbo_frame: "_top", turbo_action: :advance } do %>
           <%= user.display_name %><span class="font-normal">さん</span>
         <% end %>
       <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,14 +1,14 @@
 <div class="user-item flex flex-col items-start hover:bg-sky-100 px-[16px] py-[12px]">
   <div class="flex items-center w-full">
-    <%= link_to profile_show_path(username_slug: user.username_slug), class: "flex items-center no-underline flex-shrink-0 hover:underline", data: { turbo_frame: "main-content", turbo_action: :advance } do %>
+    <%= link_to profile_show_path(username_slug: user.username_slug), class: "flex items-center no-underline flex-shrink-0 hover:underline", data: { turbo_frame: "_top", turbo_action: :advance } do %>
       <%= image_tag(user.avatar.presence || asset_path('logo-watune-en.png'), alt: "プロフィール画像", class: "rounded-full h-[40px] w-[40px] flex-shrink-0") %>
     <% end %>
     <div class="ml-2 flex-1 overflow-hidden">
       <h3 class="text-md font-semibold truncate">
-        <%= link_to user.display_name, profile_show_path(username_slug: user.username_slug), class: "text-[15px] no-underline text-inherit hover:underline", data: { turbo_frame: "main-content", turbo_action: :advance } %>
+        <%= link_to user.display_name, profile_show_path(username_slug: user.username_slug), class: "text-[15px] no-underline text-inherit hover:underline", data: { turbo_frame: "_top", turbo_action: :advance } %>
       </h3>
       <p class="text-gray-500 truncate">
-        <%= link_to "@#{user.username_slug}", profile_show_path(username_slug: user.username_slug), class: "text-[15px] no-underline text-inherit hover:underline", data: { turbo_frame: "main-content", turbo_action: :advance } %>
+        <%= link_to "@#{user.username_slug}", profile_show_path(username_slug: user.username_slug), class: "text-[15px] no-underline text-inherit hover:underline", data: { turbo_frame: "_top", turbo_action: :advance } %>
       </p>
     </div>
     <div id="user-<%= user.id %>-follow">


### PR DESCRIPTION
現状、モーダルにすると戻るボタンが機能しなかったり、戻るでモーダルが自動に開きUIがよろしくない

また、モーダルのmodal.htmil.erbを作る必要があったり、daisyUIの使い方に沿う必要がある。ターボフレームは戻るボタンが機能しなくなる。