### PR TITLE
Fix: data-controller="history"を戻した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -34,7 +34,7 @@
 }
 
 .c-tab {
-  @apply flex-1 px-4 py-2 text-center text-lg border-b-2 border-gray-300 hover:bg-sky-100 hover:border-b-4 hover:border-sky-400 whitespace-nowrap;
+  @apply flex-1 px-4 py-2 text-center border-b-2 border-gray-300 hover:bg-sky-100 hover:border-b-4 hover:border-sky-400 whitespace-nowrap;
 }
 
 .c-tab span {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -8,7 +8,7 @@
 }
 
 .c-post-tab {
-  @apply flex-1 px-4 py-2 text-center text-lg hover:bg-sky-100 hover:border-b-4 hover:border-sky-400 whitespace-nowrap;
+  @apply flex-1 px-4 py-2 text-center text-base hover:bg-sky-100 hover:border-b-4 hover:border-sky-400 whitespace-nowrap;
 }
 
 .active {

--- a/app/javascript/controllers/post_index_controller.js
+++ b/app/javascript/controllers/post_index_controller.js
@@ -46,45 +46,52 @@ export default class extends Controller {
 
     console.log("Switching category to:", category);
 
-    // 現在のカテゴリーのスクロール位置を保存
     const currentCategory = this.getCurrentCategory();
-    this.scrollPositions[currentCategory] = window.scrollY;
-    console.log(
-      "Saving scroll position for category",
-      currentCategory,
-      ":",
-      window.scrollY
-    );
-    this.saveScrollPosition();
 
-    // Cookieを更新
-    Cookies.set("selected_post_category", category, { expires: 365 });
-    console.log("Updated cookies for category:", category);
-
-    // アクティブタブを更新
-    this.updateActiveTab();
-
-    // カテゴリーコンテンツの表示を切り替え
-    this.toggleCategoryContent(category);
-
-    // スクロール位置を復元
-    const scrollPosition = this.scrollPositions[category] || 0;
-    console.log(
-      "Restoring scroll position for category",
-      category,
-      ":",
-      scrollPosition
-    );
-    window.scrollTo({
-      top: scrollPosition,
-      behavior: "smooth",
-    });
-
-    // カテゴリーのデータがまだ読み込まれていない場合、非同期で取得
-    if (!this.loadedCategories.has(category)) {
+    if (currentCategory === category) {
+      // 同じカテゴリーが再度クリックされた場合、最新データを取得して上部にスクロール
       this.fetchCategoryPosts(category);
+      window.scrollTo({ top: 0, behavior: "auto" });
     } else {
-      this.displayCategoryPosts(category);
+      // 現在のカテゴリーのスクロール位置を保存
+      this.scrollPositions[currentCategory] = window.scrollY;
+      console.log(
+        "Saving scroll position for category",
+        currentCategory,
+        ":",
+        window.scrollY
+      );
+      this.saveScrollPosition();
+
+      // Cookieを更新
+      Cookies.set("selected_post_category", category, { expires: 365 });
+      console.log("Updated cookies for category:", category);
+
+      // アクティブタブを更新
+      this.updateActiveTab();
+
+      // カテゴリーコンテンツの表示を切り替え
+      this.toggleCategoryContent(category);
+
+      // スクロール位置を復元
+      const scrollPosition = this.scrollPositions[category] || 0;
+      console.log(
+        "Restoring scroll position for category",
+        category,
+        ":",
+        scrollPosition
+      );
+      window.scrollTo({
+        top: scrollPosition,
+        behavior: "smooth",
+      });
+
+      // カテゴリーのデータがまだ読み込まれていない場合、非同期で取得
+      if (!this.loadedCategories.has(category)) {
+        this.fetchCategoryPosts(category);
+      } else {
+        this.displayCategoryPosts(category);
+      }
     }
   }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
   <% end %>
 </head>
 
-<body id="main-body" class="font-sans bg-white flex flex-col min-h-screen" >
+<body id="main-body" class="font-sans bg-white flex flex-col min-h-screen" data-controller="history">
 
   <!-- ヘッダー -->
   <% if logged_in? %>

--- a/app/views/posts/index/_category_tabs.html.erb
+++ b/app/views/posts/index/_category_tabs.html.erb
@@ -1,4 +1,4 @@
-<div id="post-category-tabs-wrapper" class="sticky top-0 z-10 bg-white border">
+<div id="post-category-tabs-wrapper" class="sticky top-0 z-10 bg-white border text-base">
   <div id="post-category-tabs" class="flex justify-center items-center">
     <!-- タブのリンク -->
     <div id="post-category-tabs-container" class="c-tabs flex overflow-x-auto whitespace-nowrap pb-2 relative" >

--- a/app/views/posts/index/_category_tabs.html.erb
+++ b/app/views/posts/index/_category_tabs.html.erb
@@ -1,4 +1,4 @@
-<div id="post-category-tabs-wrapper" class="sticky top-0 z-10 bg-white border text-base">
+<div id="post-category-tabs-wrapper" class="sticky top-0 z-10 bg-white border">
   <div id="post-category-tabs" class="flex justify-center items-center">
     <!-- タブのリンク -->
     <div id="post-category-tabs-container" class="c-tabs flex overflow-x-auto whitespace-nowrap pb-2 relative" >

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,8 +1,7 @@
-# frozen_string_literal: true
-
+# config/initializers/rack_profiler.rb
 if Rails.env.development?
   require 'rack-mini-profiler'
-
-  # The initializer was required late, so initialize it manually.
-  Rack::MiniProfilerRails.initialize!(Rails.application)
+  
+  # rack-mini-profilerを無効にする設定
+  Rack::MiniProfiler.config.enabled = false
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced history tracking functionality on the client side by adding `data-controller="history"` to the `<body>` tag.

- **Bug Fixes**
  - Disabled `rack-mini-profiler` in the development environment to improve performance.

- **Style**
  - Adjusted text sizes and border properties for `.c-post-tab` and `.c-tab` classes.
  - Added `text-base` class to the `#post-category-tabs-wrapper` for improved text sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->