### PR TITLE
Fix: 投稿内容が重複しており修正

### DIFF
--- a/app/views/posts/shared/_body.html.erb
+++ b/app/views/posts/shared/_body.html.erb
@@ -8,7 +8,7 @@
       </div>
     <% else %>
       <div class="text-base">
-          <%= format_text_with_links(post.body) %><br>
+        <%= format_text_with_links(line) %><br>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
投稿内容が2つ表示される理由は、post.body全体をループ内で再度リンク化して表示しているため

ormat_text_with_linksメソッドを適用するために、lineをリンク化