### PR TITLE
layoutの修正(rubocop)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,8 +65,8 @@ gem 'config', '~> 5.4'
 
 # ファイルのアップロードのためのcarrierwave
 gem 'carrierwave', '~> 3.0'
-gem 'carrierwave-aws', '~> 1.6'
 gem 'carrierwave-audio', '~> 1.0'
+gem 'carrierwave-aws', '~> 1.6'
 
 # ページネーションのためのpagy
 gem 'pagy', '~> 8.3'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
     @unread_count = Rails.cache.fetch("user_#{current_user&.id}_unread_count", expires_in: 1.minute) do
       current_user&.received_notifications&.unread&.count || 0
     end
-  
+
     @notifications = current_user&.received_notifications&.unread&.limit(10)
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -31,5 +31,5 @@ class UserSessionsController < ApplicationController
     Rails.cache.delete("user_#{current_user.id}_unread_count")
     logout
     redirect_to root_path, status: :see_other, notice: t('flash_messages.user_sessions.logout')
-  end  
+  end
 end

--- a/app/uploaders/audio_uploader.rb
+++ b/app/uploaders/audio_uploader.rb
@@ -7,7 +7,7 @@ class AudioUploader < CarrierWave::Uploader::Base
   # Choose what kind of storage to use for this uploader:
   # storage :file # ローカルに保存される
   # storage :fog # 複数のクラウドに対応する
-  storage :aws  # Amazonが公式に提供するS3専用のツール（ただし、Cloudflare R2もS3互換なので使える）
+  storage :aws # Amazonが公式に提供するS3専用のツール（ただし、Cloudflare R2もS3互換なので使える）
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -18,7 +18,7 @@ class AudioUploader < CarrierWave::Uploader::Base
 
   # アップロード可能なファイル拡張子のホワイトリスト
   def extension_allowlist
-    %w(mp3 webm mp4)
+    %w[mp3 webm mp4]
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/config/config/initializers/carrierwave.rb
+++ b/config/config/initializers/carrierwave.rb
@@ -4,23 +4,23 @@ CarrierWave.configure do |config|
   config.aws_acl    = 'public-read'
 
   config.aws_credentials = {
-    access_key_id:     ENV.fetch('R2_ACCESS_KEY'),
+    access_key_id: ENV.fetch('R2_ACCESS_KEY'),
     secret_access_key: ENV.fetch('R2_SECRET_KEY'),
-    region:            'auto',  # R2のリージョン設定
-    endpoint:          ENV.fetch('R2_ENDPOINT')  # R2のエンドポイント
+    region: 'auto', # R2のリージョン設定
+    endpoint: ENV.fetch('R2_ENDPOINT') # R2のエンドポイント
   }
 end
 
 CarrierWave.configure do |config|
   config.storage    = :aws
   config.aws_bucket = Rails.application.credentials.dig(:cloudflare, :r2_bucket)
-  config.aws_acl    = 'public-read'  # 必要に応じて変更
+  config.aws_acl    = 'public-read' # 必要に応じて変更
 
   config.aws_credentials = {
-    access_key_id:     Rails.application.credentials.dig(:cloudflare, :r2_access_key_id),
+    access_key_id: Rails.application.credentials.dig(:cloudflare, :r2_access_key_id),
     secret_access_key: Rails.application.credentials.dig(:cloudflare, :r2_secret_access_key),
-    region:            'auto',
-    endpoint:          Rails.application.credentials.dig(:cloudflare, :r2_endpoint), # エンドポイントの設定
-    force_path_style:  true  # Cloudflare R2はパススタイルアクセスが必要
+    region: 'auto',
+    endpoint: Rails.application.credentials.dig(:cloudflare, :r2_endpoint), # エンドポイントの設定
+    force_path_style: true # Cloudflare R2はパススタイルアクセスが必要
   }
 end


### PR DESCRIPTION
## 関連issue
#588 

## 概要
<!--このPull Requestの目的を簡潔に説明してください。-->
- `rubocop -a`を実行し、プロジェクト内のコードスタイルを改善しました。

## 実装内容
- Gemfile内のGemsの並び順をアルファベット順に修正し、`carrierwave-audio`を`carrierwave-aws`の前に配置しました。<br>
- 各ファイル内で末尾に不要な空白が存在していた箇所を削除しました。<br>
- コード内で変数や値の間に余分なスペースがあった箇所を削除しました。<br>
- 複数行にわたるハッシュリテラルのキーと値を整列させ、可読性を向上させました。<br>
- `%w`リテラルの括弧を丸括弧から角括弧に変更し、一貫性を持たせました。<br>

## 備考
- これらの修正は、機能やロジックには影響を与えず、コードのスタイルと可読性を向上させるものです。
